### PR TITLE
Fixes for the keycloak quarkus image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - shanoir_ng_network
   keycloak:
     container_name: "${SHANOIR_PREFIX}keycloak"
+    #command: ["start-dev"]   # default is "start" to run in production mode
     environment:
       - SHANOIR_ADMIN_EMAIL
       - SHANOIR_ADMIN_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - SHANOIR_KEYCLOAK_USER
       - SHANOIR_KEYCLOAK_PASSWORD
       - SHANOIR_ALLOWED_ADMIN_IPS
-      - KC_HTTP_RELATIVE_PATH=/auth
     build: ./docker-compose/keycloak
     networks:
       - shanoir_ng_network

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -33,7 +33,7 @@ RUN /opt/keycloak/bin/kc.sh build
 FROM quay.io/keycloak/keycloak:20.0.0
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
-COPY themes/. /opt/keycloak/themes
+COPY --chown=keycloak themes/. /opt/keycloak/themes
 COPY cfg/. /opt/keycloak/
 
 COPY entrypoint entrypoint_common oneshot /bin/

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -44,4 +44,4 @@ COPY entrypoint entrypoint_common oneshot /bin/
 # (like all other env vars)
 ENV PROXY_ADDRESS_FORWARDING ""
 
-ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm", "--hostname-path=/auth", "--proxy=edge", "--spi-theme-welcome-theme=shanoir-theme"]
+ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -10,10 +10,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html
 
+ARG BASE_IMAGE=quay.io/keycloak/keycloak:20.0.0
+
 #
 # Use builder to integrate custom provider
 #
-FROM quay.io/keycloak/keycloak:20.0.0 as builder
+FROM $BASE_IMAGE as builder
 
 COPY shanoir-ng-keycloak-auth.jar /opt/keycloak/providers
 
@@ -30,7 +32,7 @@ RUN /opt/keycloak/bin/kc.sh build
 #
 # Create actual image, based on builder before
 #
-FROM quay.io/keycloak/keycloak:20.0.0
+FROM $BASE_IMAGE
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY --chown=keycloak themes/. /opt/keycloak/themes

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -33,4 +33,5 @@ COPY cfg/. /opt/keycloak/
 
 COPY entrypoint entrypoint_common oneshot /bin/
 
-ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh", "start-dev"]
+ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh"]
+CMD ["start"]

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -34,9 +34,6 @@ FROM quay.io/keycloak/keycloak:20.0.0
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY themes/. /opt/keycloak/themes
-USER root
-RUN chmod 666 /opt/keycloak/themes/shanoir-theme/login/template.ftl
-USER keycloak
 COPY cfg/. /opt/keycloak/
 
 COPY entrypoint entrypoint_common oneshot /bin/

--- a/docker-compose/keycloak/Dockerfile
+++ b/docker-compose/keycloak/Dockerfile
@@ -19,13 +19,6 @@ FROM $BASE_IMAGE as builder
 
 COPY shanoir-ng-keycloak-auth.jar /opt/keycloak/providers
 
-# Configure a database vendor
-ENV KC_DB=mysql
-
-# Enable health and metrics support
-ENV KC_HEALTH_ENABLED=true
-ENV KC_METRICS_ENABLED=true
-
 WORKDIR /opt/keycloak
 RUN /opt/keycloak/bin/kc.sh build
 
@@ -40,8 +33,4 @@ COPY cfg/. /opt/keycloak/
 
 COPY entrypoint entrypoint_common oneshot /bin/
 
-# unset the env var, so that the default value is set by the entrypoint script
-# (like all other env vars)
-ENV PROXY_ADDRESS_FORWARDING ""
-
-ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]
+ENTRYPOINT ["/bin/entrypoint", "/opt/keycloak/bin/kc.sh", "start-dev"]

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -26,11 +26,21 @@ sed "	s/SHANOIR_ADMIN_NAME/$SHANOIR_ADMIN_NAME/g
 sed -i -E "s/SHANOIR_URL_SCHEME/$SHANOIR_URL_SCHEME/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
 sed -i -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
 
+#
+# keycloak options
+# see: https://www.keycloak.org/server/all-config
+#
+export KC_HOSTNAME_PATH="/auth"
+export KC_HTTP_RELATIVE_PATH="/auth"
+export KC_PROXY="${KC_PROXY:-edge}"
+export KC_SPI_THEME_WELCOME_THEME="shanoir-theme"
+
 export KC_DB="${DB_VENDOR:-mysql}"
 export KC_DB_URL=jdbc:mysql://"${DB_ADDR:-${SHANOIR_PREFIX}keycloak-database}":"${DB_PORT:-3306}"/"${DB_DATABASE:-keycloak}"
 export KC_DB_USERNAME="${DB_USER:-keycloak}"
 export KC_DB_PASSWORD="${DB_PASSWORD:-password}"
 export PROXY_ADDRESS_FORWARDING="${PROXY_ADDRESS_FORWARDING:-true}"
+
 
 require  SHANOIR_MIGRATION
 oneshot=

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -13,7 +13,7 @@ require  SHANOIR_URL_HOST
 require  SHANOIR_VIEWER_OHIF_URL_SCHEME
 require  SHANOIR_VIEWER_OHIF_URL_HOST
 
-mkdir -p /opt/keycloak/data/import
+mkdir -p /tmp/import
 sed "	s/SHANOIR_ADMIN_NAME/$SHANOIR_ADMIN_NAME/g
 		s/SHANOIR_ADMIN_EMAIL/$SHANOIR_ADMIN_EMAIL/g
 		s/SHANOIR_SMTP_HOST/$SHANOIR_SMTP_HOST/g
@@ -21,7 +21,7 @@ sed "	s/SHANOIR_ADMIN_NAME/$SHANOIR_ADMIN_NAME/g
 		s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g
 		s/SHANOIR_VIEWER_OHIF_URL_SCHEME/$SHANOIR_VIEWER_OHIF_URL_SCHEME/g
 		s/SHANOIR_VIEWER_OHIF_URL_HOST/$SHANOIR_VIEWER_OHIF_URL_HOST/g
-"		/opt/keycloak/shanoir-ng-realm.json > /opt/keycloak/data/import/shanoir-ng-realm.json
+"		/opt/keycloak/shanoir-ng-realm.json > /tmp/import/shanoir-ng-realm.json
 
 sed -i -E "s/SHANOIR_URL_SCHEME/$SHANOIR_URL_SCHEME/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
 sed -i -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
@@ -56,7 +56,7 @@ extra=("-Dms.users.url=http://${SHANOIR_PREFIX}users:9901"
 case "$SHANOIR_MIGRATION" in
 auto|dev)
 	# create the shanoir-ng realm if it does not exist yet
-	extra+=("-Dkeycloak.import=/opt/keycloak/data/import/shanoir-ng-realm.json"
+	extra+=("-Dkeycloak.import=/tmp/import/shanoir-ng-realm.json"
 		"-Dkeycloak.migration.strategy=IGNORE_EXISTING")
 	;;
 init)
@@ -73,7 +73,7 @@ init)
 	# wipe out the shanoir-ng realm and recreate it
 	extra+=("-Dkeycloak.migration.action=import"
 		"-Dkeycloak.migration.provider=singleFile"
-		"-Dkeycloak.migration.file=/opt/keycloak/data/import/shanoir-ng-realm.json"
+		"-Dkeycloak.migration.file=/tmp/import/shanoir-ng-realm.json"
 		"-Dkeycloak.migration.strategy=OVERWRITE_EXISTING")
 
         # FIXME: should check additional messages:

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -39,7 +39,6 @@ export KC_DB="${DB_VENDOR:-mysql}"
 export KC_DB_URL=jdbc:mysql://"${DB_ADDR:-${SHANOIR_PREFIX}keycloak-database}":"${DB_PORT:-3306}"/"${DB_DATABASE:-keycloak}"
 export KC_DB_USERNAME="${DB_USER:-keycloak}"
 export KC_DB_PASSWORD="${DB_PASSWORD:-password}"
-export PROXY_ADDRESS_FORWARDING="${PROXY_ADDRESS_FORWARDING:-true}"
 
 
 require  SHANOIR_MIGRATION

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -34,6 +34,13 @@ export KC_HTTP_RELATIVE_PATH="/auth"
 export KC_PROXY="${KC_PROXY:-edge}"
 export KC_SPI_THEME_WELCOME_THEME="shanoir-theme"
 
+# we disable strict hostname checking by default because:
+# - the reverse proxy in production implements this check
+# - since the 'nginx' container does not expose the master realm to the
+#   outside, disabling strict checking allows us to reach the admin console
+#   at http://localhost:8080/auth/admin/
+export KC_HOSTNAME_STRICT="${KC_HOSTNAME_STRICT:false}"
+
 export KC_DB="${DB_VENDOR:-mysql}"
 export KC_DB_URL=jdbc:mysql://"${DB_ADDR:-${SHANOIR_PREFIX}keycloak-database}":"${DB_PORT:-3306}"/"${DB_DATABASE:-keycloak}"
 export KC_DB_USERNAME="${DB_USER:-keycloak}"

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -23,12 +23,8 @@ sed "	s/SHANOIR_ADMIN_NAME/$SHANOIR_ADMIN_NAME/g
 		s/SHANOIR_VIEWER_OHIF_URL_HOST/$SHANOIR_VIEWER_OHIF_URL_HOST/g
 "		/opt/keycloak/shanoir-ng-realm.json > /opt/keycloak/data/import/shanoir-ng-realm.json
 
-sed -E "s/SHANOIR_URL_SCHEME/$SHANOIR_URL_SCHEME/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl > /tmp/template.ftl
-cat /tmp/template.ftl > /opt/keycloak/themes/shanoir-theme/login/template.ftl
-rm /tmp/template.ftl
-sed -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl > /tmp/template.ftl
-cat /tmp/template.ftl > /opt/keycloak/themes/shanoir-theme/login/template.ftl
-rm /tmp/template.ftl
+sed -i -E "s/SHANOIR_URL_SCHEME/$SHANOIR_URL_SCHEME/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
+sed -i -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-theme/login/template.ftl 
 
 export KC_DB="${DB_VENDOR:-mysql}"
 export KC_DB_URL=jdbc:mysql://"${DB_ADDR:-${SHANOIR_PREFIX}keycloak-database}":"${DB_PORT:-3306}"/"${DB_DATABASE:-keycloak}"

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -30,7 +30,6 @@ sed -i -E "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" /opt/keycloak/themes/shanoir-
 # keycloak options
 # see: https://www.keycloak.org/server/all-config
 #
-export KC_HOSTNAME_PATH="/auth"
 export KC_HTTP_RELATIVE_PATH="/auth"
 export KC_PROXY="${KC_PROXY:-edge}"
 export KC_SPI_THEME_WELCOME_THEME="shanoir-theme"

--- a/docker-compose/keycloak/entrypoint
+++ b/docker-compose/keycloak/entrypoint
@@ -42,6 +42,7 @@ export KC_DB_PASSWORD="${DB_PASSWORD:-password}"
 
 require  SHANOIR_MIGRATION
 oneshot=
+patterns=(' \[io.quarkus\] \(main\) Keycloak .* started in [0-9.]+*s')
 extra=("-Dms.users.url=http://${SHANOIR_PREFIX}users:9901"
        "-Dallowed.admin.ips=${SHANOIR_ALLOWED_ADMIN_IPS}")
 
@@ -55,6 +56,12 @@ init)
 	# create the admin account
 	export KEYCLOAK_ADMIN="$SHANOIR_KEYCLOAK_USER"
 	export KEYCLOAK_ADMIN_PASSWORD="$SHANOIR_KEYCLOAK_PASSWORD"
+
+	# The admin account is created after server is started, thus to avoid a
+	# race condition we need to match a KC-SERVICES0009 (user added to
+	# realm) or a KC-SERVICES0010 (user already exists) before stopping the
+	# server
+	patterns+=('KC-SERVICES0009|KC-SERVICES0010')
 
 	# wipe out the shanoir-ng realm and recreate it
 	extra+=("-Dkeycloak.migration.action=import"
@@ -143,13 +150,13 @@ if [ -n "$oneshot" ] ; then
 	# (i.e: startup, import/export, warning, errors, ...)
 	sed '	/[0-9] INFO /{
 			/\[org\.keycloak\./p
+			/\[io\.quarkus\]/p
 			d
 		}' <"$fifo" &
-			
-	exec oneshot						\
-		' .*org\.keycloak\.quarkus\.runtime\.KeycloakMain.*Running the server'	\
-		-- env "$@" "${extra[@]}" > "$fifo"
-			
+
+	# run until the server is fully started
+	exec oneshot "${patterns[@]}" -- env "$@" "${extra[@]}" > "$fifo"
+
 else
 	# 'normal' run
 	exec env "$@" "${extra[@]}"

--- a/utils/oneshot
+++ b/utils/oneshot
@@ -24,8 +24,10 @@ process . The ordering is strict: they must be matched in the same order as
 given in the command line.
 
 After the last PATTERN is matched, the oneshot script sends  SIGTERM to the
-process, then wait for its termination and exit with code 0 if all PATTERNs
-have been matched successfully or code 1 otherwise.
+process, then wait for its termination.
+
+The exit code is the numeber of remaining PATTERNs to be matched (0 if all
+PATTERNs were matched successfully).
 EOF
 	exit 0
 fi
@@ -37,33 +39,37 @@ while [ "$1" != "--" ] ; do
 done
 shift
 
-fifo1="`tmp_fifo`"
-fifo2="`tmp_fifo`"
+# run the command with its outputs redirected to a fifo
 
-exec "$@" >"$fifo1" 2>&1 &
+fifo="`tmp_fifo`"
+trap "rm $fifo" EXIT
+
+exec "$@" >"$fifo" 2>&1 &
 pid=$!
 trap "kill $pid" INT TERM
 
-tee "$fifo2" <"$fifo1" &
+# read from the fifo and match each pattern in order
+IFS=
+current=0
+while read -r line ; do
+	echo "$line"
+	if [[ "$line" =~ ${patterns[$current]} ]] ; then
+		if [ $((++current)) -eq ${#patterns[@]} ] ; then
+			echo "  ------------------- sending SIGTERM -----------------------"
+			kill "$pid" || true
+			while read -r line ; do
+				echo "$line"
+			done
+			break
+		fi
+	fi
+done <"$fifo"
 
-set +e
-(	set -e
-	trap 'cat >/dev/null &' EXIT
-	for pattern in "${patterns[@]}"
-	do
-		grep -E -q -m1 -- "$pattern"
-	done
-) <"$fifo2"
-result=$?
-rm "$fifo1" "$fifo2"
+# eof
 
-if [ "$result" -eq 0 ] ; then
-	# successful
-	echo "  ------------------- sending SIGTERM -------------------"
-	kill "$pid"
-fi
+wait "$pid" || true
 
-wait "$pid"
+result=$((${#patterns[@]} - current))
 echo "  ------------------- terminated (exit $result) -------------------"
 exit "$result"
 

--- a/utils/oneshot
+++ b/utils/oneshot
@@ -39,6 +39,11 @@ while [ "$1" != "--" ] ; do
 done
 shift
 
+if [ ${#patterns[@]} -eq 0 ] ; then
+	echo "oneshot: error: must provide at least one pattern" >&2
+	exit 100
+fi
+
 # run the command with its outputs redirected to a fifo
 
 fifo="`tmp_fifo`"
@@ -66,6 +71,13 @@ while read -r line ; do
 done <"$fifo"
 
 # eof
+
+echo "  ------------------- match report --------------------------"
+i=0
+for pattern in "${patterns[@]}" ; do
+	[ $((i++)) -lt $current ] && status="\e[32m OK \e[39m" || status="\e[31mFAIL\e[39m"
+	echo "  [ `echo -e "$status"` ]  $pattern"
+done
 
 wait "$pid" || true
 


### PR DESCRIPTION
- fix the patterns to be matched in keycloak's output (they worked only in  development mode)
- fix a race condition in the 'oneshot' script
- fix import issues (actually revert unnecessary changes introduced by 5cb5cadb3140)
- revert the permission fixes in d0d06f70d67d..3158f347a2063 and implement a much simpler one
- move all keycloak config keys into the entrypoint script (instead of spreading them over the entrypoint, dockerfile & docker-compose.yml)
- remove dead code and unneeded config var
- disable strict hostname checking (to allow reaching the admin console at http://localhost:8080/auth/admin)
- run in production mode by default

There is an open question : development mode can be enabled by uncommenting  the `#command: ["start-dev"]`
line in the docker-compose file.  I considered using the `docker-compose-dev.yml` file instead but it does not seem to be well-formatted (do you actually use it?), so I just put the dev option in the `docker-compose.yml` but commented.